### PR TITLE
feat: inline keyboards for schedule and location

### DIFF
--- a/bus_bot.py
+++ b/bus_bot.py
@@ -4,9 +4,9 @@ import os
 import pytz
 import telegram
 from dotenv import load_dotenv
-from telegram import ParseMode, Update
-from telegram.ext import (CallbackContext, CommandHandler, Filters,
-                          MessageHandler, Updater)
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, ParseMode, Update
+from telegram.ext import (CallbackContext, CallbackQueryHandler,
+                          CommandHandler, Filters, MessageHandler, Updater)
 
 load_dotenv(override=True)
 
@@ -63,23 +63,11 @@ SATURDAY_LAST_DROPOFF = "20:45"
 LOCATION_BUTTONS = [
     "ASR", "Outram Park MRT Exit 6", "Outram Park MRT Exit 7", "Harbourfront MRT Exit D",
 ]
-SCHEDULE_BUTTONS = [
-    "ASR Schedule", "Outram Park MRT Exit 6 Schedule",
-    "Outram Park MRT Exit 7 Schedule", "Harbourfront MRT Exit D Schedule",
-]
-
 LOCATION_BUTTON_MAP = {
     "asr": "asr",
     "outram park mrt exit 6": "outram_exit_6",
     "outram park mrt exit 7": "outram_exit_7",
     "harbourfront mrt exit d": "harbourfront",
-}
-
-SCHEDULE_BUTTON_MAP = {
-    "asr schedule": "asr",
-    "outram park mrt exit 6 schedule": "outram_exit_6",
-    "outram park mrt exit 7 schedule": "outram_exit_7",
-    "harbourfront mrt exit d schedule": "harbourfront",
 }
 
 intro_text = """
@@ -187,30 +175,26 @@ def start(update: Update, context: CallbackContext) -> None:
     update.message.reply_text(disclaimer, parse_mode=ParseMode.HTML)
 
 
+def schedule_inline_keyboard():
+    return InlineKeyboardMarkup([
+        [InlineKeyboardButton(f"📍 {STOP_NAMES[k]}", callback_data=f"schedule:{k}")]
+        for k in STOP_NAMES
+    ])
+
+
 def prompt_schedule(update: Update, context: CallbackContext) -> None:
     day_type = get_day_type()
     label = "Saturday" if day_type == "saturday" else "Weekday"
-
-    keyboard = [[telegram.KeyboardButton(b)] for b in SCHEDULE_BUTTONS]
-    reply_markup = telegram.ReplyKeyboardMarkup(keyboard, one_time_keyboard=True)
 
     if day_type == "sunday":
         msg = "😴 Sunday no bus lah.\n📋 Showing <b>Weekday</b> schedule.\nWhich stop you want?"
     else:
         msg = f"📋 <b>{label} Schedule</b>\nWhich stop you want to see?"
-    update.message.reply_text(msg, reply_markup=reply_markup, parse_mode=ParseMode.HTML)
+    update.message.reply_text(msg, reply_markup=schedule_inline_keyboard(),
+                              parse_mode=ParseMode.HTML)
 
 
-def get_schedule(update: Update, context: CallbackContext) -> None:
-    stop_key = SCHEDULE_BUTTON_MAP.get(update.message.text.lower())
-    if not stop_key:
-        update.message.reply_text("Paiseh, I don't understand leh. Try /schedule again?")
-        return
-
-    day_type = get_day_type()
-    if day_type == "sunday":
-        day_type = "weekday"
-
+def build_schedule_text(stop_key, day_type):
     trips = get_trips_for_day_type(day_type)
     breaks = weekday_breaks if day_type == "weekday" else saturday_breaks
     last_dropoff = WEEKDAY_LAST_DROPOFF if day_type == "weekday" else SATURDAY_LAST_DROPOFF
@@ -222,8 +206,24 @@ def get_schedule(update: Update, context: CallbackContext) -> None:
     else:
         body = format_stop_schedule(trips, stop_key, breaks)
 
-    update.message.reply_text(header + body, parse_mode=ParseMode.HTML)
-    update.message.reply_text(service_notice, parse_mode=ParseMode.HTML)
+    return header + body + "\n" + service_notice
+
+
+def handle_schedule_callback(update: Update, context: CallbackContext) -> None:
+    query = update.callback_query
+    query.answer()
+
+    stop_key = query.data.split(":")[1]
+    if stop_key not in STOP_NAMES:
+        return
+
+    day_type = get_day_type()
+    if day_type == "sunday":
+        day_type = "weekday"
+
+    text = build_schedule_text(stop_key, day_type)
+    query.edit_message_text(text, parse_mode=ParseMode.HTML,
+                            reply_markup=schedule_inline_keyboard())
 
 
 def prompt_location(update: Update, context: CallbackContext) -> None:
@@ -285,10 +285,8 @@ def main() -> None:
 
     dp.add_handler(CommandHandler("start", start))
     dp.add_handler(CommandHandler("schedule", prompt_schedule))
+    dp.add_handler(CallbackQueryHandler(handle_schedule_callback, pattern=r"^schedule:"))
     dp.add_handler(CommandHandler("location", prompt_location))
-    dp.add_handler(
-        MessageHandler(Filters.text(SCHEDULE_BUTTONS), get_schedule)
-    )
     dp.add_handler(MessageHandler(Filters.text & ~Filters.command, next_bus_time))
 
     updater.start_polling()

--- a/bus_bot.py
+++ b/bus_bot.py
@@ -2,11 +2,10 @@ import datetime
 import os
 
 import pytz
-import telegram
 from dotenv import load_dotenv
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, ParseMode, Update
 from telegram.ext import (CallbackContext, CallbackQueryHandler,
-                          CommandHandler, Filters, MessageHandler, Updater)
+                          CommandHandler, Updater)
 
 load_dotenv(override=True)
 
@@ -60,15 +59,6 @@ saturday_breaks = {
 WEEKDAY_LAST_DROPOFF = "20:15"
 SATURDAY_LAST_DROPOFF = "20:45"
 
-LOCATION_BUTTONS = [
-    "ASR", "Outram Park MRT Exit 6", "Outram Park MRT Exit 7", "Harbourfront MRT Exit D",
-]
-LOCATION_BUTTON_MAP = {
-    "asr": "asr",
-    "outram park mrt exit 6": "outram_exit_6",
-    "outram park mrt exit 7": "outram_exit_7",
-    "harbourfront mrt exit d": "harbourfront",
-}
 
 intro_text = """
 🚌 Eh hello neighbour! I help you check ASR bus timing one.
@@ -226,31 +216,25 @@ def handle_schedule_callback(update: Update, context: CallbackContext) -> None:
                             reply_markup=schedule_inline_keyboard())
 
 
+def location_inline_keyboard():
+    return InlineKeyboardMarkup([
+        [InlineKeyboardButton(f"📍 {STOP_NAMES[k]}", callback_data=f"location:{k}")]
+        for k in STOP_NAMES
+    ])
+
+
 def prompt_location(update: Update, context: CallbackContext) -> None:
     if get_day_type() == "sunday":
         update.message.reply_text(no_sunday_service, parse_mode=ParseMode.HTML)
         return
 
-    keyboard = [[telegram.KeyboardButton(b)] for b in LOCATION_BUTTONS]
-    reply_markup = telegram.ReplyKeyboardMarkup(keyboard, one_time_keyboard=True)
-    update.message.reply_text("📍 Where you at now ah?", reply_markup=reply_markup)
+    update.message.reply_text("📍 Where you at now ah?",
+                              reply_markup=location_inline_keyboard(),
+                              parse_mode=ParseMode.HTML)
 
 
-def next_bus_time(update: Update, context: CallbackContext) -> None:
-    day_type = get_day_type()
-    if day_type == "sunday":
-        update.message.reply_text(no_sunday_service, parse_mode=ParseMode.HTML)
-        return
-
+def build_next_bus_text(stop_key, day_type):
     current_time = get_singapore_now().time()
-    stop_key = LOCATION_BUTTON_MAP.get(update.message.text.lower())
-
-    if not stop_key:
-        update.message.reply_text(
-            "Paiseh, I don't understand leh 😅 Try /location again?"
-        )
-        return
-
     trips = get_trips_for_day_type(day_type)
     schedule = get_stop_schedule(trips, stop_key)
 
@@ -258,25 +242,41 @@ def next_bus_time(update: Update, context: CallbackContext) -> None:
         bus_time = datetime.datetime.strptime(time_str, "%H:%M").time()
         if current_time <= bus_time:
             mins = minutes_until(current_time, bus_time)
-            msg = format_bus_msg("Next bus departs" if stop_key == "asr" else "Next bus arrives",
-                                 mins, time_str, stop_key, trip_type)
-            update.message.reply_text(msg, parse_mode=ParseMode.HTML)
+            lines = [format_bus_msg(
+                "Next bus departs" if stop_key == "asr" else "Next bus arrives",
+                mins, time_str, stop_key, trip_type)]
 
             if i < len(schedule) - 1:
                 next_time, next_type = schedule[i + 1]
                 next_bus = datetime.datetime.strptime(next_time, "%H:%M").time()
                 next_mins = minutes_until(current_time, next_bus)
-                following = format_bus_msg("Following bus", next_mins, next_time,
-                                           stop_key, next_type)
-                update.message.reply_text(following, parse_mode=ParseMode.HTML)
+                lines.append(format_bus_msg("Following bus", next_mins, next_time,
+                                            stop_key, next_type))
             else:
-                update.message.reply_text("☝️ Last bus already, no more after this one!")
+                lines.append("☝️ Last bus already, no more after this one!")
 
-            update.message.reply_text(service_notice, parse_mode=ParseMode.HTML)
-            return
+            lines.append(service_notice)
+            return "\n".join(lines)
 
-    update.message.reply_text("😢 Aiyoh, no more bus today already!")
-    update.message.reply_text(service_notice, parse_mode=ParseMode.HTML)
+    return "😢 Aiyoh, no more bus today already!" + "\n" + service_notice
+
+
+def handle_location_callback(update: Update, context: CallbackContext) -> None:
+    query = update.callback_query
+    query.answer()
+
+    stop_key = query.data.split(":")[1]
+    if stop_key not in STOP_NAMES:
+        return
+
+    day_type = get_day_type()
+    if day_type == "sunday":
+        query.edit_message_text(no_sunday_service, parse_mode=ParseMode.HTML)
+        return
+
+    text = build_next_bus_text(stop_key, day_type)
+    query.edit_message_text(text, parse_mode=ParseMode.HTML,
+                            reply_markup=location_inline_keyboard())
 
 
 def main() -> None:
@@ -287,7 +287,7 @@ def main() -> None:
     dp.add_handler(CommandHandler("schedule", prompt_schedule))
     dp.add_handler(CallbackQueryHandler(handle_schedule_callback, pattern=r"^schedule:"))
     dp.add_handler(CommandHandler("location", prompt_location))
-    dp.add_handler(MessageHandler(Filters.text & ~Filters.command, next_bus_time))
+    dp.add_handler(CallbackQueryHandler(handle_location_callback, pattern=r"^location:"))
 
     updater.start_polling()
     updater.idle()

--- a/bus_bot.py
+++ b/bus_bot.py
@@ -19,6 +19,8 @@ STOP_NAMES = {
     "harbourfront": "Harbourfront MRT Exit D",
 }
 
+STOP_EMOJIS = {"asr": "🏠", "outram_exit_6": "🚇", "outram_exit_7": "🚇", "harbourfront": "🛍️"}
+
 STOP_OFFSETS = {"asr": 0, "outram_exit_6": 6, "outram_exit_7": 8, "harbourfront": 10}
 
 TRIP_TYPE_STOPS = {
@@ -167,7 +169,7 @@ def start(update: Update, context: CallbackContext) -> None:
 
 def schedule_inline_keyboard():
     return InlineKeyboardMarkup([
-        [InlineKeyboardButton(f"📍 {STOP_NAMES[k]}", callback_data=f"schedule:{k}")]
+        [InlineKeyboardButton(f"{STOP_EMOJIS[k]} {STOP_NAMES[k]}", callback_data=f"schedule:{k}")]
         for k in STOP_NAMES
     ])
 
@@ -218,7 +220,7 @@ def handle_schedule_callback(update: Update, context: CallbackContext) -> None:
 
 def location_inline_keyboard():
     return InlineKeyboardMarkup([
-        [InlineKeyboardButton(f"📍 {STOP_NAMES[k]}", callback_data=f"location:{k}")]
+        [InlineKeyboardButton(f"{STOP_EMOJIS[k]} {STOP_NAMES[k]}", callback_data=f"location:{k}")]
         for k in STOP_NAMES
     ])
 

--- a/test_bus_bot.py
+++ b/test_bus_bot.py
@@ -12,14 +12,14 @@ from bus_bot import (
     add_minutes,
     minutes_until,
     next_bus_time,
-    get_schedule,
+    build_schedule_text,
+    handle_schedule_callback,
     prompt_location,
+    prompt_schedule,
     format_asr_schedule,
     format_stop_schedule,
+    STOP_NAMES,
     STOP_OFFSETS,
-    TRIP_DESTINATIONS,
-    SCHEDULE_BUTTONS,
-    SCHEDULE_BUTTON_MAP,
     LOCATION_BUTTONS,
     LOCATION_BUTTON_MAP,
 )
@@ -217,37 +217,81 @@ class TestNextBusTime(unittest.TestCase):
         self.assertTrue(any("min" in c for c in calls))
 
 
-class TestGetSchedule(unittest.TestCase):
+class TestBuildScheduleText(unittest.TestCase):
+
+    def test_asr_weekday_schedule(self):
+        text = build_schedule_text("asr", "weekday")
+        self.assertIn("07:20", text)
+        self.assertIn("Outram Park MRT", text)
+        self.assertIn("Harbourfront MRT Exit D", text)
+        self.assertIn("Weekday", text)
+
+    def test_harbourfront_weekday_schedule(self):
+        text = build_schedule_text("harbourfront", "weekday")
+        self.assertIn("Harbourfront MRT Exit D", text)
+        self.assertNotIn("07:20", text)
+
+    def test_saturday_schedule(self):
+        text = build_schedule_text("asr", "saturday")
+        self.assertIn("Saturday", text)
+        self.assertIn("09:00", text)
+
+
+class TestScheduleInlineKeyboard(unittest.TestCase):
 
     def setUp(self):
         self.mock_update = Mock()
         self.mock_context = Mock()
+
+    @patch('bus_bot.get_day_type', return_value="weekday")
+    def test_prompt_schedule_sends_inline_keyboard(self, _):
         self.mock_update.message.reply_text = Mock()
-
-    @patch('bus_bot.get_day_type', return_value="weekday")
-    def test_asr_schedule_display(self, _):
-        self.mock_update.message.text = "ASR Schedule"
-        get_schedule(self.mock_update, self.mock_context)
-        self.assertEqual(self.mock_update.message.reply_text.call_count, 2)
-        body = self.mock_update.message.reply_text.call_args_list[0][0][0]
-        self.assertIn("07:20", body)
-        self.assertIn("Outram Park MRT", body)
-        self.assertIn("Harbourfront MRT Exit D", body)
-
-    @patch('bus_bot.get_day_type', return_value="weekday")
-    def test_harbourfront_schedule_display(self, _):
-        self.mock_update.message.text = "Harbourfront MRT Exit D Schedule"
-        get_schedule(self.mock_update, self.mock_context)
-        body = self.mock_update.message.reply_text.call_args_list[0][0][0]
-        self.assertIn("Harbourfront MRT Exit D", body)
-        self.assertNotIn("07:20", body)
+        prompt_schedule(self.mock_update, self.mock_context)
+        call_kwargs = self.mock_update.message.reply_text.call_args[1]
+        reply_markup = call_kwargs.get("reply_markup")
+        self.assertIsNotNone(reply_markup)
+        buttons = [btn for row in reply_markup.inline_keyboard for btn in row]
+        self.assertEqual(len(buttons), len(STOP_NAMES))
+        callback_data = [btn.callback_data for btn in buttons]
+        for stop_key in STOP_NAMES:
+            self.assertIn(f"schedule:{stop_key}", callback_data)
 
     @patch('bus_bot.get_day_type', return_value="sunday")
-    def test_sunday_shows_weekday(self, _):
-        self.mock_update.message.text = "ASR Schedule"
-        get_schedule(self.mock_update, self.mock_context)
-        body = self.mock_update.message.reply_text.call_args_list[0][0][0]
-        self.assertIn("Weekday", body)
+    def test_prompt_schedule_sunday_message(self, _):
+        self.mock_update.message.reply_text = Mock()
+        prompt_schedule(self.mock_update, self.mock_context)
+        msg = self.mock_update.message.reply_text.call_args[0][0]
+        self.assertIn("Sunday no bus lah", msg)
+
+    @patch('bus_bot.get_day_type', return_value="weekday")
+    def test_handle_schedule_callback_edits_message(self, _):
+        query = Mock()
+        query.data = "schedule:asr"
+        self.mock_update.callback_query = query
+        handle_schedule_callback(self.mock_update, self.mock_context)
+        query.answer.assert_called_once()
+        query.edit_message_text.assert_called_once()
+        text = query.edit_message_text.call_args[0][0]
+        self.assertIn("07:20", text)
+        self.assertIn("Weekday", text)
+
+    @patch('bus_bot.get_day_type', return_value="sunday")
+    def test_handle_schedule_callback_sunday_shows_weekday(self, _):
+        query = Mock()
+        query.data = "schedule:asr"
+        self.mock_update.callback_query = query
+        handle_schedule_callback(self.mock_update, self.mock_context)
+        text = query.edit_message_text.call_args[0][0]
+        self.assertIn("Weekday", text)
+
+    @patch('bus_bot.get_day_type', return_value="weekday")
+    def test_handle_schedule_callback_keeps_inline_keyboard(self, _):
+        query = Mock()
+        query.data = "schedule:harbourfront"
+        self.mock_update.callback_query = query
+        handle_schedule_callback(self.mock_update, self.mock_context)
+        call_kwargs = query.edit_message_text.call_args[1]
+        self.assertIn("reply_markup", call_kwargs)
 
 
 class TestPromptLocation(unittest.TestCase):
@@ -288,10 +332,6 @@ class TestButtonMaps(unittest.TestCase):
     def test_location_buttons_all_mapped(self):
         for button in LOCATION_BUTTONS:
             self.assertIn(button.lower(), LOCATION_BUTTON_MAP)
-
-    def test_schedule_buttons_all_mapped(self):
-        for button in SCHEDULE_BUTTONS:
-            self.assertIn(button.lower(), SCHEDULE_BUTTON_MAP)
 
 
 class TestScheduleAccuracy(unittest.TestCase):

--- a/test_bus_bot.py
+++ b/test_bus_bot.py
@@ -11,8 +11,9 @@ from bus_bot import (
     get_trips_for_day_type,
     add_minutes,
     minutes_until,
-    next_bus_time,
+    build_next_bus_text,
     build_schedule_text,
+    handle_location_callback,
     handle_schedule_callback,
     prompt_location,
     prompt_schedule,
@@ -20,8 +21,6 @@ from bus_bot import (
     format_stop_schedule,
     STOP_NAMES,
     STOP_OFFSETS,
-    LOCATION_BUTTONS,
-    LOCATION_BUTTON_MAP,
 )
 
 
@@ -158,63 +157,86 @@ class TestDayType(unittest.TestCase):
         self.assertIsNone(get_trips_for_day_type("sunday"))
 
 
-class TestNextBusTime(unittest.TestCase):
+class TestBuildNextBusText(unittest.TestCase):
+
+    @patch('bus_bot.get_singapore_now')
+    def test_next_bus_asr_morning(self, mock_now):
+        mock_now.return_value = Mock(time=Mock(return_value=datetime.time(7, 25)))
+        text = build_next_bus_text("asr", "weekday")
+        self.assertIn("min", text)
+        self.assertIn("Going to", text)
+
+    @patch('bus_bot.get_singapore_now')
+    def test_all_buses_passed(self, mock_now):
+        mock_now.return_value = Mock(time=Mock(return_value=datetime.time(21, 0)))
+        text = build_next_bus_text("asr", "weekday")
+        self.assertIn("no more bus", text.lower())
+
+    @patch('bus_bot.get_singapore_now')
+    def test_next_bus_harbourfront(self, mock_now):
+        mock_now.return_value = Mock(time=Mock(return_value=datetime.time(10, 5)))
+        text = build_next_bus_text("harbourfront", "weekday")
+        self.assertIn("min", text)
+
+
+class TestLocationInlineKeyboard(unittest.TestCase):
 
     def setUp(self):
         self.mock_update = Mock()
         self.mock_context = Mock()
+
+    @patch('bus_bot.get_day_type', return_value="weekday")
+    def test_prompt_location_sends_inline_keyboard(self, _):
         self.mock_update.message.reply_text = Mock()
+        prompt_location(self.mock_update, self.mock_context)
+        call_kwargs = self.mock_update.message.reply_text.call_args[1]
+        reply_markup = call_kwargs.get("reply_markup")
+        self.assertIsNotNone(reply_markup)
+        buttons = [btn for row in reply_markup.inline_keyboard for btn in row]
+        self.assertEqual(len(buttons), len(STOP_NAMES))
+        callback_data = [btn.callback_data for btn in buttons]
+        for stop_key in STOP_NAMES:
+            self.assertIn(f"location:{stop_key}", callback_data)
 
     @patch('bus_bot.get_day_type', return_value="sunday")
-    def test_sunday_no_service(self, _):
-        self.mock_update.message.text = "ASR"
-        next_bus_time(self.mock_update, self.mock_context)
-        call_args = self.mock_update.message.reply_text.call_args[0][0]
-        self.assertIn("sunday no bus lah", call_args.lower())
+    def test_prompt_location_sunday_no_service(self, _):
+        self.mock_update.message.reply_text = Mock()
+        prompt_location(self.mock_update, self.mock_context)
+        msg = self.mock_update.message.reply_text.call_args[0][0]
+        self.assertIn("sunday no bus lah", msg.lower())
 
     @patch('bus_bot.get_singapore_now')
     @patch('bus_bot.get_day_type', return_value="weekday")
-    def test_next_bus_asr_morning(self, _, mock_now):
+    def test_handle_location_callback_edits_message(self, _, mock_now):
         mock_now.return_value = Mock(time=Mock(return_value=datetime.time(7, 25)))
-        self.mock_update.message.text = "ASR"
-        next_bus_time(self.mock_update, self.mock_context)
-        calls = [c[0][0] for c in self.mock_update.message.reply_text.call_args_list]
-        self.assertTrue(any("min" in c for c in calls))
-        self.assertTrue(any("Going to" in c for c in calls))
+        query = Mock()
+        query.data = "location:asr"
+        self.mock_update.callback_query = query
+        handle_location_callback(self.mock_update, self.mock_context)
+        query.answer.assert_called_once()
+        query.edit_message_text.assert_called_once()
+        text = query.edit_message_text.call_args[0][0]
+        self.assertIn("min", text)
+
+    @patch('bus_bot.get_day_type', return_value="sunday")
+    def test_handle_location_callback_sunday(self, _):
+        query = Mock()
+        query.data = "location:asr"
+        self.mock_update.callback_query = query
+        handle_location_callback(self.mock_update, self.mock_context)
+        text = query.edit_message_text.call_args[0][0]
+        self.assertIn("sunday no bus lah", text.lower())
 
     @patch('bus_bot.get_singapore_now')
     @patch('bus_bot.get_day_type', return_value="weekday")
-    def test_all_buses_passed(self, _, mock_now):
-        mock_now.return_value = Mock(time=Mock(return_value=datetime.time(21, 0)))
-        self.mock_update.message.text = "ASR"
-        next_bus_time(self.mock_update, self.mock_context)
-        calls = [c[0][0] for c in self.mock_update.message.reply_text.call_args_list]
-        self.assertTrue(any("no more bus" in c.lower() for c in calls))
-
-    @patch('bus_bot.get_singapore_now')
-    @patch('bus_bot.get_day_type', return_value="weekday")
-    def test_next_bus_harbourfront(self, _, mock_now):
-        mock_now.return_value = Mock(time=Mock(return_value=datetime.time(10, 5)))
-        self.mock_update.message.text = "Harbourfront MRT Exit D"
-        next_bus_time(self.mock_update, self.mock_context)
-        calls = [c[0][0] for c in self.mock_update.message.reply_text.call_args_list]
-        self.assertTrue(any("min" in c for c in calls))
-
-    @patch('bus_bot.get_day_type', return_value="weekday")
-    def test_invalid_location(self, _):
-        self.mock_update.message.text = "somewhere else"
-        next_bus_time(self.mock_update, self.mock_context)
-        call_args = self.mock_update.message.reply_text.call_args[0][0]
-        self.assertIn("Paiseh", call_args)
-
-    @patch('bus_bot.get_singapore_now')
-    @patch('bus_bot.get_day_type', return_value="weekday")
-    def test_case_insensitive(self, _, mock_now):
+    def test_handle_location_callback_keeps_inline_keyboard(self, _, mock_now):
         mock_now.return_value = Mock(time=Mock(return_value=datetime.time(7, 0)))
-        self.mock_update.message.text = "outram park mrt exit 6"
-        next_bus_time(self.mock_update, self.mock_context)
-        calls = [c[0][0] for c in self.mock_update.message.reply_text.call_args_list]
-        self.assertTrue(any("min" in c for c in calls))
+        query = Mock()
+        query.data = "location:outram_exit_6"
+        self.mock_update.callback_query = query
+        handle_location_callback(self.mock_update, self.mock_context)
+        call_kwargs = query.edit_message_text.call_args[1]
+        self.assertIn("reply_markup", call_kwargs)
 
 
 class TestBuildScheduleText(unittest.TestCase):
@@ -294,20 +316,6 @@ class TestScheduleInlineKeyboard(unittest.TestCase):
         self.assertIn("reply_markup", call_kwargs)
 
 
-class TestPromptLocation(unittest.TestCase):
-
-    def setUp(self):
-        self.mock_update = Mock()
-        self.mock_context = Mock()
-        self.mock_update.message.reply_text = Mock()
-
-    @patch('bus_bot.get_day_type', return_value="sunday")
-    def test_sunday_no_service(self, _):
-        prompt_location(self.mock_update, self.mock_context)
-        call_args = self.mock_update.message.reply_text.call_args[0][0]
-        self.assertIn("sunday no bus lah", call_args.lower())
-
-
 class TestFormatting(unittest.TestCase):
 
     def test_asr_schedule_contains_breaks(self):
@@ -325,13 +333,6 @@ class TestFormatting(unittest.TestCase):
         text = format_stop_schedule(weekday_trips, "outram_exit_6", weekday_breaks)
         self.assertIn("07:26", text)
         self.assertNotIn("→", text)
-
-
-class TestButtonMaps(unittest.TestCase):
-
-    def test_location_buttons_all_mapped(self):
-        for button in LOCATION_BUTTONS:
-            self.assertIn(button.lower(), LOCATION_BUTTON_MAP)
 
 
 class TestScheduleAccuracy(unittest.TestCase):
@@ -409,110 +410,75 @@ class TestScheduleAccuracy(unittest.TestCase):
 
 class TestNextBusEdgeCases(unittest.TestCase):
 
-    def setUp(self):
-        self.mock_update = Mock()
-        self.mock_context = Mock()
-        self.mock_update.message.reply_text = Mock()
-
     @patch('bus_bot.get_singapore_now')
-    @patch('bus_bot.get_day_type', return_value="weekday")
-    def test_during_lunch_break_finds_next_trip(self, _, mock_now):
+    def test_during_lunch_break_finds_next_trip(self, mock_now):
         """At 12:30 (weekday lunch break 12:00-13:00), next ASR bus is 13:00."""
         mock_now.return_value = Mock(time=Mock(return_value=datetime.time(12, 30)))
-        self.mock_update.message.text = "ASR"
-        next_bus_time(self.mock_update, self.mock_context)
-        calls = [c[0][0] for c in self.mock_update.message.reply_text.call_args_list]
-        first_reply = calls[0]
-        self.assertIn("30 min", first_reply)
-        self.assertIn("13:00", first_reply)
+        text = build_next_bus_text("asr", "weekday")
+        self.assertIn("30 min", text)
+        self.assertIn("13:00", text)
 
     @patch('bus_bot.get_singapore_now')
-    @patch('bus_bot.get_day_type', return_value="weekday")
-    def test_last_bus_no_following(self, _, mock_now):
+    def test_last_bus_no_following(self, mock_now):
         """At 19:55, next ASR bus is 20:00 (last one) — no following bus."""
         mock_now.return_value = Mock(time=Mock(return_value=datetime.time(19, 55)))
-        self.mock_update.message.text = "ASR"
-        next_bus_time(self.mock_update, self.mock_context)
-        calls = [c[0][0] for c in self.mock_update.message.reply_text.call_args_list]
-        self.assertTrue(any("5 min" in c for c in calls))
-        self.assertTrue(any("last bus already" in c.lower() for c in calls))
+        text = build_next_bus_text("asr", "weekday")
+        self.assertIn("5 min", text)
+        self.assertIn("last bus already", text.lower())
 
     @patch('bus_bot.get_singapore_now')
-    @patch('bus_bot.get_day_type', return_value="weekday")
-    def test_next_bus_shows_following(self, _, mock_now):
+    def test_next_bus_shows_following(self, mock_now):
         """At 07:00, next bus is 07:20 and following is 07:40 — both shown."""
         mock_now.return_value = Mock(time=Mock(return_value=datetime.time(7, 0)))
-        self.mock_update.message.text = "ASR"
-        next_bus_time(self.mock_update, self.mock_context)
-        calls = [c[0][0] for c in self.mock_update.message.reply_text.call_args_list]
-        self.assertTrue(any("07:20" in c for c in calls))
-        self.assertTrue(any("07:40" in c for c in calls))
+        text = build_next_bus_text("asr", "weekday")
+        self.assertIn("07:20", text)
+        self.assertIn("07:40", text)
 
     @patch('bus_bot.get_singapore_now')
-    @patch('bus_bot.get_day_type', return_value="saturday")
-    def test_saturday_next_bus(self, _, mock_now):
+    def test_saturday_next_bus(self, mock_now):
         """Saturday at 09:15, next ASR bus should be 09:30 (type B → Harbourfront)."""
         mock_now.return_value = Mock(time=Mock(return_value=datetime.time(9, 15)))
-        self.mock_update.message.text = "ASR"
-        next_bus_time(self.mock_update, self.mock_context)
-        calls = [c[0][0] for c in self.mock_update.message.reply_text.call_args_list]
-        first_reply = calls[0]
-        self.assertIn("15 min", first_reply)
-        self.assertIn("Harbourfront", first_reply)
+        text = build_next_bus_text("asr", "saturday")
+        self.assertIn("15 min", text)
+        self.assertIn("Harbourfront", text)
 
     @patch('bus_bot.get_singapore_now')
-    @patch('bus_bot.get_day_type', return_value="saturday")
-    def test_saturday_all_buses_passed(self, _, mock_now):
+    def test_saturday_all_buses_passed(self, mock_now):
         """Saturday at 21:00, all buses should have passed."""
         mock_now.return_value = Mock(time=Mock(return_value=datetime.time(21, 0)))
-        self.mock_update.message.text = "Outram Park MRT Exit 6"
-        next_bus_time(self.mock_update, self.mock_context)
-        calls = [c[0][0] for c in self.mock_update.message.reply_text.call_args_list]
-        self.assertTrue(any("no more bus" in c.lower() for c in calls))
+        text = build_next_bus_text("outram_exit_6", "saturday")
+        self.assertIn("no more bus", text.lower())
 
     @patch('bus_bot.get_singapore_now')
-    @patch('bus_bot.get_day_type', return_value="weekday")
-    def test_harbourfront_during_morning_no_service(self, _, mock_now):
+    def test_harbourfront_during_morning_no_service(self, mock_now):
         """Weekday at 08:30, no Harbourfront buses yet (first is 10:10)."""
         mock_now.return_value = Mock(time=Mock(return_value=datetime.time(8, 30)))
-        self.mock_update.message.text = "Harbourfront MRT Exit D"
-        next_bus_time(self.mock_update, self.mock_context)
-        calls = [c[0][0] for c in self.mock_update.message.reply_text.call_args_list]
-        first_reply = calls[0]
-        self.assertIn("10:10", first_reply)
+        text = build_next_bus_text("harbourfront", "weekday")
+        self.assertIn("10:10", text)
 
     @patch('bus_bot.get_singapore_now')
-    @patch('bus_bot.get_day_type', return_value="weekday")
-    def test_asr_destination_alternates(self, _, mock_now):
+    def test_asr_destination_alternates(self, mock_now):
         """At 09:25, next ASR bus is 09:30 (A→Outram), following is 10:00 (B→Harbourfront)."""
         mock_now.return_value = Mock(time=Mock(return_value=datetime.time(9, 25)))
-        self.mock_update.message.text = "ASR"
-        next_bus_time(self.mock_update, self.mock_context)
-        calls = [c[0][0] for c in self.mock_update.message.reply_text.call_args_list]
-        self.assertIn("Outram Park MRT", calls[0])
-        self.assertIn("Harbourfront MRT Exit D", calls[1])
+        text = build_next_bus_text("asr", "weekday")
+        self.assertIn("Outram Park MRT", text)
+        self.assertIn("Harbourfront MRT Exit D", text)
 
     @patch('bus_bot.get_singapore_now')
-    @patch('bus_bot.get_day_type', return_value="weekday")
-    def test_exact_departure_time_still_shown(self, _, mock_now):
+    def test_exact_departure_time_still_shown(self, mock_now):
         """At exactly 07:20, the 07:20 bus should still be shown (0 min)."""
         mock_now.return_value = Mock(time=Mock(return_value=datetime.time(7, 20)))
-        self.mock_update.message.text = "ASR"
-        next_bus_time(self.mock_update, self.mock_context)
-        calls = [c[0][0] for c in self.mock_update.message.reply_text.call_args_list]
-        self.assertTrue(any("07:20" in c for c in calls))
-        self.assertTrue(any("0 min" in c for c in calls))
+        text = build_next_bus_text("asr", "weekday")
+        self.assertIn("07:20", text)
+        self.assertIn("0 min", text)
 
     @patch('bus_bot.get_singapore_now')
-    @patch('bus_bot.get_day_type', return_value="weekday")
-    def test_exact_last_bus_time(self, _, mock_now):
+    def test_exact_last_bus_time(self, mock_now):
         """At exactly 20:00, the last bus should still be shown, not 'all passed'."""
         mock_now.return_value = Mock(time=Mock(return_value=datetime.time(20, 0)))
-        self.mock_update.message.text = "ASR"
-        next_bus_time(self.mock_update, self.mock_context)
-        calls = [c[0][0] for c in self.mock_update.message.reply_text.call_args_list]
-        self.assertTrue(any("20:00" in c for c in calls))
-        self.assertFalse(any("no more bus" in c.lower() for c in calls))
+        text = build_next_bus_text("asr", "weekday")
+        self.assertIn("20:00", text)
+        self.assertNotIn("no more bus", text.lower())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Replace `ReplyKeyboardMarkup` with `InlineKeyboardMarkup` for both `/schedule` and `/location`
- Messages update in-place when users tap stop buttons — no need to re-type the command
- Stop buttons persist after selection so users can quickly switch between stops
- Per-stop emojis on buttons: 🏠 ASR, 🚇 Outram exits, 🛍️ Harbourfront
- Removed `SCHEDULE_BUTTONS`, `SCHEDULE_BUTTON_MAP`, `LOCATION_BUTTONS`, `LOCATION_BUTTON_MAP`, `MessageHandler`, and `Filters` (no longer needed)
- Extracted `build_schedule_text()` and `build_next_bus_text()` for cleaner separation of logic and display

## Test plan
- [x] All 59 tests pass (`python -m unittest test_bus_bot -v`)
- [ ] Deploy and verify `/schedule` shows inline buttons, tapping switches schedule in-place
- [ ] Deploy and verify `/location` shows inline buttons, tapping shows next bus in-place
- [ ] Verify Sunday shows no-service message for `/location`

🤖 Generated with [Claude Code](https://claude.com/claude-code)