### PR TITLE
Add Dependabot for weekly uv dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to enable automated dependency updates
- Configured for `uv` package ecosystem with weekly schedule

## Test plan
- [ ] Verify Dependabot picks up the config and starts creating PRs for outdated dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)