### PR TITLE
feat: add Railpack start command for Railway deployment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ dependencies = [
     "holidays==0.95",
     "setuptools<81",
 ]
+
+[tool.railpack]
+start = "python bus_bot.py"


### PR DESCRIPTION
## Summary
- Add `[tool.railpack]` section to `pyproject.toml` with start command for Railway deployment
- Fixes Railpack build error: "No start command detected"

## Test plan
- [ ] Verify Railway build succeeds without "no start command" error
- [ ] Verify bot starts correctly on Railway

🤖 Generated with [Claude Code](https://claude.com/claude-code)