### PR TITLE
fix: use railpack.json for Railpack config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,3 @@ dependencies = [
     "holidays==0.95",
     "setuptools<81",
 ]
-
-[tool.railpack]
-start = "python bus_bot.py"

--- a/railpack.json
+++ b/railpack.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://schema.railpack.com",
+  "steps": {
+    "install": {
+      "commands": ["uv sync"]
+    }
+  },
+  "deploy": {
+    "startCommand": "uv run python bus_bot.py"
+  }
+}


### PR DESCRIPTION
## Summary
- Removed invalid `[tool.railpack]` section from `pyproject.toml` — this is not a recognized Railpack configuration format
- Added proper `railpack.json` with `deploy.startCommand` and `uv sync` install step per [Railpack docs](https://railpack.com/config/file)

## Test plan
- [ ] Deploy to Railway and verify the bot starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)