### PR TITLE
fix: use copy commands in railpack install step

### DIFF
--- a/railpack.json
+++ b/railpack.json
@@ -2,13 +2,11 @@
   "$schema": "https://schema.railpack.com",
   "steps": {
     "install": {
-      "inputs": [
-        {
-          "local": true,
-          "include": ["."]
-        }
-      ],
-      "commands": ["uv sync"]
+      "commands": [
+        { "src": "pyproject.toml", "dest": "pyproject.toml" },
+        { "src": "uv.lock", "dest": "uv.lock" },
+        "uv sync"
+      ]
     }
   },
   "deploy": {


### PR DESCRIPTION
## Summary
- Replace `local` input with copy commands (`src`/`dest`) in the Railpack install step
- Fixes build error: `✖ 'install' inputs must be an image or step input`
- The first input of a Railpack step must be a step or image reference — a `local` input cannot be first. Using copy commands for `pyproject.toml` and `uv.lock` lets the step use the default base layer and also enables better dependency layer caching.

## Test plan
- [ ] Verify Railway build succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)