### PR TITLE
chore: adopt ruff as linter/formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,6 @@ jobs:
 
       - run: uv sync
 
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .
       - run: uv run pytest -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/bus_bot.py
+++ b/bus_bot.py
@@ -6,8 +6,7 @@ import holidays
 from dotenv import load_dotenv
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.constants import ParseMode
-from telegram.ext import (Application, CallbackQueryHandler,
-                          CommandHandler, ContextTypes)
+from telegram.ext import Application, CallbackQueryHandler, CommandHandler, ContextTypes
 
 load_dotenv(override=True)
 
@@ -34,19 +33,52 @@ TRIP_TYPE_STOPS = {
 TRIP_DESTINATIONS = {"A": "Outram Park MRT", "B": "Harbourfront MRT Exit D"}
 
 weekday_trips = [
-    ("07:20", "A"), ("07:40", "A"), ("08:00", "A"), ("08:20", "A"), ("08:40", "A"), ("09:00", "A"),
-    ("09:30", "A"), ("10:00", "B"), ("10:30", "A"), ("11:00", "B"), ("11:30", "A"),
-    ("13:00", "B"), ("13:30", "A"), ("14:00", "B"), ("14:30", "A"), ("15:00", "B"),
-    ("16:30", "A"), ("17:00", "B"), ("17:30", "A"), ("18:00", "B"), ("18:30", "A"),
-    ("19:00", "B"), ("19:30", "A"), ("20:00", "B"),
+    ("07:20", "A"),
+    ("07:40", "A"),
+    ("08:00", "A"),
+    ("08:20", "A"),
+    ("08:40", "A"),
+    ("09:00", "A"),
+    ("09:30", "A"),
+    ("10:00", "B"),
+    ("10:30", "A"),
+    ("11:00", "B"),
+    ("11:30", "A"),
+    ("13:00", "B"),
+    ("13:30", "A"),
+    ("14:00", "B"),
+    ("14:30", "A"),
+    ("15:00", "B"),
+    ("16:30", "A"),
+    ("17:00", "B"),
+    ("17:30", "A"),
+    ("18:00", "B"),
+    ("18:30", "A"),
+    ("19:00", "B"),
+    ("19:30", "A"),
+    ("20:00", "B"),
 ]
 
 saturday_trips = [
-    ("09:00", "A"), ("09:30", "B"), ("10:00", "A"), ("10:30", "B"), ("11:00", "A"),
-    ("11:30", "B"), ("12:00", "A"), ("12:30", "B"),
-    ("14:00", "A"), ("14:30", "B"), ("15:00", "A"), ("15:30", "B"), ("16:00", "A"),
+    ("09:00", "A"),
+    ("09:30", "B"),
+    ("10:00", "A"),
+    ("10:30", "B"),
+    ("11:00", "A"),
+    ("11:30", "B"),
+    ("12:00", "A"),
+    ("12:30", "B"),
+    ("14:00", "A"),
+    ("14:30", "B"),
+    ("15:00", "A"),
+    ("15:30", "B"),
+    ("16:00", "A"),
     ("16:30", "B"),
-    ("18:00", "A"), ("18:30", "B"), ("19:00", "A"), ("19:30", "B"), ("20:00", "A"),
+    ("18:00", "A"),
+    ("18:30", "B"),
+    ("19:00", "A"),
+    ("19:30", "B"),
+    ("20:00", "A"),
     ("20:30", "B"),
 ]
 
@@ -129,8 +161,10 @@ def minutes_until(current_time, target_time):
 
 def format_bus_msg(label, minutes, time_str, stop_key, trip_type):
     if stop_key == "asr":
-        return (f"🚌 {label} in <b>{minutes} min</b> ({time_str})\n"
-                f"➡️ Going to <b>{TRIP_DESTINATIONS[trip_type]}</b>")
+        return (
+            f"🚌 {label} in <b>{minutes} min</b> ({time_str})\n"
+            f"➡️ Going to <b>{TRIP_DESTINATIONS[trip_type]}</b>"
+        )
     return f"🚌 {label} in <b>{minutes} min</b> ({time_str})"
 
 
@@ -172,10 +206,16 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
 
 def schedule_inline_keyboard():
-    return InlineKeyboardMarkup([
-        [InlineKeyboardButton(f"{STOP_EMOJIS[k]} {STOP_NAMES[k]}", callback_data=f"schedule:{k}")]
-        for k in STOP_NAMES
-    ])
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton(
+                    f"{STOP_EMOJIS[k]} {STOP_NAMES[k]}", callback_data=f"schedule:{k}"
+                )
+            ]
+            for k in STOP_NAMES
+        ]
+    )
 
 
 async def prompt_schedule(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -186,8 +226,9 @@ async def prompt_schedule(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         msg = "😴 Sunday no bus lah.\n📋 Showing <b>Weekday</b> schedule.\nWhich stop you want?"
     else:
         msg = f"📋 <b>{label} Schedule</b>\nWhich stop you want to see?"
-    await update.message.reply_text(msg, reply_markup=schedule_inline_keyboard(),
-                                    parse_mode=ParseMode.HTML)
+    await update.message.reply_text(
+        msg, reply_markup=schedule_inline_keyboard(), parse_mode=ParseMode.HTML
+    )
 
 
 def build_schedule_text(stop_key, day_type):
@@ -218,15 +259,22 @@ async def handle_schedule_callback(update: Update, context: ContextTypes.DEFAULT
         day_type = "weekday"
 
     text = build_schedule_text(stop_key, day_type)
-    await query.edit_message_text(text, parse_mode=ParseMode.HTML,
-                                  reply_markup=schedule_inline_keyboard())
+    await query.edit_message_text(
+        text, parse_mode=ParseMode.HTML, reply_markup=schedule_inline_keyboard()
+    )
 
 
 def location_inline_keyboard():
-    return InlineKeyboardMarkup([
-        [InlineKeyboardButton(f"{STOP_EMOJIS[k]} {STOP_NAMES[k]}", callback_data=f"location:{k}")]
-        for k in STOP_NAMES
-    ])
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton(
+                    f"{STOP_EMOJIS[k]} {STOP_NAMES[k]}", callback_data=f"location:{k}"
+                )
+            ]
+            for k in STOP_NAMES
+        ]
+    )
 
 
 async def prompt_location(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -234,9 +282,11 @@ async def prompt_location(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         await update.message.reply_text(no_sunday_service, parse_mode=ParseMode.HTML)
         return
 
-    await update.message.reply_text("📍 Where you at now ah?",
-                                    reply_markup=location_inline_keyboard(),
-                                    parse_mode=ParseMode.HTML)
+    await update.message.reply_text(
+        "📍 Where you at now ah?",
+        reply_markup=location_inline_keyboard(),
+        parse_mode=ParseMode.HTML,
+    )
 
 
 def build_next_bus_text(stop_key, day_type):
@@ -248,16 +298,23 @@ def build_next_bus_text(stop_key, day_type):
         bus_time = datetime.datetime.strptime(time_str, "%H:%M").time()
         if current_time <= bus_time:
             mins = minutes_until(current_time, bus_time)
-            lines = [format_bus_msg(
-                "Next bus departs" if stop_key == "asr" else "Next bus arrives",
-                mins, time_str, stop_key, trip_type)]
+            lines = [
+                format_bus_msg(
+                    "Next bus departs" if stop_key == "asr" else "Next bus arrives",
+                    mins,
+                    time_str,
+                    stop_key,
+                    trip_type,
+                )
+            ]
 
             if i < len(schedule) - 1:
                 next_time, next_type = schedule[i + 1]
                 next_bus = datetime.datetime.strptime(next_time, "%H:%M").time()
                 next_mins = minutes_until(current_time, next_bus)
-                lines.append(format_bus_msg("Following bus", next_mins, next_time,
-                                            stop_key, next_type))
+                lines.append(
+                    format_bus_msg("Following bus", next_mins, next_time, stop_key, next_type)
+                )
             else:
                 lines.append("☝️ Last bus already, no more after this one!")
 
@@ -281,8 +338,9 @@ async def handle_location_callback(update: Update, context: ContextTypes.DEFAULT
         return
 
     text = build_next_bus_text(stop_key, day_type)
-    await query.edit_message_text(text, parse_mode=ParseMode.HTML,
-                                  reply_markup=location_inline_keyboard())
+    await query.edit_message_text(
+        text, parse_mode=ParseMode.HTML, reply_markup=location_inline_keyboard()
+    )
 
 
 def main() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,14 @@ asyncio_mode = "auto"
 
 [dependency-groups]
 dev = [
+    "pre-commit>=4.6.0",
     "pytest>=8",
     "pytest-asyncio>=0.24",
+    "ruff>=0.15.12",
 ]
+
+[tool.ruff]
+line-length = 99
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]

--- a/test_bus_bot.py
+++ b/test_bus_bot.py
@@ -4,31 +4,29 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from bus_bot import (
-    weekday_trips,
-    saturday_trips,
-    weekday_breaks,
-    get_stop_schedule,
-    get_day_type,
-    get_trips_for_day_type,
-    add_minutes,
-    minutes_until,
-    build_next_bus_text,
-    build_schedule_text,
-    handle_location_callback,
-    handle_schedule_callback,
-    prompt_location,
-    prompt_schedule,
-    format_asr_schedule,
-    format_stop_schedule,
+    SG_HOLIDAYS,
     STOP_NAMES,
     STOP_OFFSETS,
-    SG_HOLIDAYS,
+    add_minutes,
+    build_next_bus_text,
+    build_schedule_text,
+    format_asr_schedule,
+    format_stop_schedule,
+    get_day_type,
+    get_stop_schedule,
+    get_trips_for_day_type,
+    handle_location_callback,
+    handle_schedule_callback,
+    minutes_until,
+    prompt_location,
+    prompt_schedule,
+    saturday_trips,
+    weekday_breaks,
+    weekday_trips,
 )
 
 
-
 class TestTripData:
-
     def test_weekday_trip_count(self):
         assert len(weekday_trips) == 24
 
@@ -71,9 +69,7 @@ class TestTripData:
         assert saturday_trips[-1] == ("20:30", "B")
 
 
-
 class TestHelpers:
-
     def test_add_minutes(self):
         assert add_minutes("07:20", 6) == "07:26"
         assert add_minutes("07:20", 8) == "07:28"
@@ -133,23 +129,21 @@ class TestHelpers:
                 prev = t
 
 
-
 class TestDayType:
-
     @pytest.mark.parametrize("day", range(5))
     @patch("bus_bot.get_singapore_now")
     def test_weekday_detection(self, mock_now, day):
-        mock_now.return_value = datetime.datetime(2026, 1, 5 + day, 10, 0, tzinfo=datetime.timezone.utc)
+        mock_now.return_value = datetime.datetime(2026, 1, 5 + day, 10, 0, tzinfo=datetime.UTC)
         assert get_day_type() == "weekday"
 
     @patch("bus_bot.get_singapore_now")
     def test_saturday_detection(self, mock_now):
-        mock_now.return_value = datetime.datetime(2026, 1, 10, 10, 0, tzinfo=datetime.timezone.utc)
+        mock_now.return_value = datetime.datetime(2026, 1, 10, 10, 0, tzinfo=datetime.UTC)
         assert get_day_type() == "saturday"
 
     @patch("bus_bot.get_singapore_now")
     def test_sunday_detection(self, mock_now):
-        mock_now.return_value = datetime.datetime(2026, 1, 11, 10, 0, tzinfo=datetime.timezone.utc)
+        mock_now.return_value = datetime.datetime(2026, 1, 11, 10, 0, tzinfo=datetime.UTC)
         assert get_day_type() == "sunday"
 
     def test_get_trips_weekday(self):
@@ -162,31 +156,29 @@ class TestDayType:
         assert get_trips_for_day_type("sunday") is None
 
 
-
 class TestPublicHoliday:
-
     @patch("bus_bot.get_singapore_now")
     def test_weekday_public_holiday_returns_saturday(self, mock_now):
         """2026-01-01 (New Year's Day) is a Thursday — should return saturday."""
-        mock_now.return_value = datetime.datetime(2026, 1, 1, 10, 0, tzinfo=datetime.timezone.utc)
+        mock_now.return_value = datetime.datetime(2026, 1, 1, 10, 0, tzinfo=datetime.UTC)
         assert get_day_type() == "saturday"
 
     @patch("bus_bot.get_singapore_now")
     def test_sunday_public_holiday_returns_sunday(self, mock_now):
         """2026-08-09 (National Day) is a Sunday — should still return sunday."""
-        mock_now.return_value = datetime.datetime(2026, 8, 9, 10, 0, tzinfo=datetime.timezone.utc)
+        mock_now.return_value = datetime.datetime(2026, 8, 9, 10, 0, tzinfo=datetime.UTC)
         assert get_day_type() == "sunday"
 
     @patch("bus_bot.get_singapore_now")
     def test_saturday_public_holiday_returns_saturday(self, mock_now):
         """2028-01-01 (New Year's Day) is a Saturday."""
-        mock_now.return_value = datetime.datetime(2028, 1, 1, 10, 0, tzinfo=datetime.timezone.utc)
+        mock_now.return_value = datetime.datetime(2028, 1, 1, 10, 0, tzinfo=datetime.UTC)
         assert get_day_type() == "saturday"
 
     @patch("bus_bot.get_singapore_now")
     def test_normal_weekday_not_holiday(self, mock_now):
         """2026-01-05 (Monday, not a holiday) — should return weekday."""
-        mock_now.return_value = datetime.datetime(2026, 1, 5, 10, 0, tzinfo=datetime.timezone.utc)
+        mock_now.return_value = datetime.datetime(2026, 1, 5, 10, 0, tzinfo=datetime.UTC)
         assert get_day_type() == "weekday"
 
     def test_sg_holidays_contains_known_dates(self):
@@ -194,9 +186,7 @@ class TestPublicHoliday:
         assert datetime.date(2026, 8, 9) in SG_HOLIDAYS
 
 
-
 class TestBuildNextBusText:
-
     @patch("bus_bot.get_singapore_now")
     def test_next_bus_asr_morning(self, mock_now):
         mock_now.return_value = Mock(time=Mock(return_value=datetime.time(7, 25)))
@@ -217,9 +207,7 @@ class TestBuildNextBusText:
         assert "min" in text
 
 
-
 class TestLocationInlineKeyboard:
-
     def setup_method(self):
         self.mock_update = Mock()
         self.mock_context = Mock()
@@ -278,9 +266,7 @@ class TestLocationInlineKeyboard:
         assert "reply_markup" in call_kwargs
 
 
-
 class TestBuildScheduleText:
-
     def test_asr_weekday_schedule(self):
         text = build_schedule_text("asr", "weekday")
         assert "07:20" in text
@@ -299,9 +285,7 @@ class TestBuildScheduleText:
         assert "09:00" in text
 
 
-
 class TestScheduleInlineKeyboard:
-
     def setup_method(self):
         self.mock_update = Mock()
         self.mock_context = Mock()
@@ -357,9 +341,7 @@ class TestScheduleInlineKeyboard:
         assert "reply_markup" in call_kwargs
 
 
-
 class TestFormatting:
-
     def test_asr_schedule_contains_breaks(self):
         text = format_asr_schedule(weekday_trips, weekday_breaks, "20:15")
         assert "Driver Break" in text
@@ -377,9 +359,7 @@ class TestFormatting:
         assert "→" not in text
 
 
-
 class TestScheduleAccuracy:
-
     @staticmethod
     def times(schedule):
         return [t for t, _ in schedule]
@@ -387,72 +367,136 @@ class TestScheduleAccuracy:
     def test_weekday_outram_exit_6_times(self):
         times = self.times(get_stop_schedule(weekday_trips, "outram_exit_6"))
         expected = [
-            "07:26", "07:46", "08:06", "08:26", "08:46", "09:06",
-            "09:36", "10:36", "11:36",
-            "13:36", "14:36",
-            "16:36", "17:36", "18:36", "19:36",
+            "07:26",
+            "07:46",
+            "08:06",
+            "08:26",
+            "08:46",
+            "09:06",
+            "09:36",
+            "10:36",
+            "11:36",
+            "13:36",
+            "14:36",
+            "16:36",
+            "17:36",
+            "18:36",
+            "19:36",
         ]
         assert times == expected
 
     def test_weekday_outram_exit_7_times(self):
         times = self.times(get_stop_schedule(weekday_trips, "outram_exit_7"))
         expected = [
-            "07:28", "07:48", "08:08", "08:28", "08:48", "09:08",
-            "09:38", "10:38", "11:38",
-            "13:38", "14:38",
-            "16:38", "17:38", "18:38", "19:38",
+            "07:28",
+            "07:48",
+            "08:08",
+            "08:28",
+            "08:48",
+            "09:08",
+            "09:38",
+            "10:38",
+            "11:38",
+            "13:38",
+            "14:38",
+            "16:38",
+            "17:38",
+            "18:38",
+            "19:38",
         ]
         assert times == expected
 
     def test_weekday_harbourfront_times(self):
         times = self.times(get_stop_schedule(weekday_trips, "harbourfront"))
         expected = [
-            "10:10", "11:10",
-            "13:10", "14:10", "15:10",
-            "17:10", "18:10", "19:10", "20:10",
+            "10:10",
+            "11:10",
+            "13:10",
+            "14:10",
+            "15:10",
+            "17:10",
+            "18:10",
+            "19:10",
+            "20:10",
         ]
         assert times == expected
 
     def test_saturday_outram_exit_6_times(self):
         times = self.times(get_stop_schedule(saturday_trips, "outram_exit_6"))
         expected = [
-            "09:06", "10:06", "11:06", "12:06",
-            "14:06", "15:06", "16:06",
-            "18:06", "19:06", "20:06",
+            "09:06",
+            "10:06",
+            "11:06",
+            "12:06",
+            "14:06",
+            "15:06",
+            "16:06",
+            "18:06",
+            "19:06",
+            "20:06",
         ]
         assert times == expected
 
     def test_saturday_outram_exit_7_times(self):
         times = self.times(get_stop_schedule(saturday_trips, "outram_exit_7"))
         expected = [
-            "09:08", "10:08", "11:08", "12:08",
-            "14:08", "15:08", "16:08",
-            "18:08", "19:08", "20:08",
+            "09:08",
+            "10:08",
+            "11:08",
+            "12:08",
+            "14:08",
+            "15:08",
+            "16:08",
+            "18:08",
+            "19:08",
+            "20:08",
         ]
         assert times == expected
 
     def test_saturday_harbourfront_times(self):
         times = self.times(get_stop_schedule(saturday_trips, "harbourfront"))
         expected = [
-            "09:40", "10:40", "11:40", "12:40",
-            "14:40", "15:40", "16:40",
-            "18:40", "19:40", "20:40",
+            "09:40",
+            "10:40",
+            "11:40",
+            "12:40",
+            "14:40",
+            "15:40",
+            "16:40",
+            "18:40",
+            "19:40",
+            "20:40",
         ]
         assert times == expected
 
     def test_saturday_asr_times(self):
         times = self.times(get_stop_schedule(saturday_trips, "asr"))
         expected = [
-            "09:00", "09:30", "10:00", "10:30", "11:00", "11:30", "12:00", "12:30",
-            "14:00", "14:30", "15:00", "15:30", "16:00", "16:30",
-            "18:00", "18:30", "19:00", "19:30", "20:00", "20:30",
+            "09:00",
+            "09:30",
+            "10:00",
+            "10:30",
+            "11:00",
+            "11:30",
+            "12:00",
+            "12:30",
+            "14:00",
+            "14:30",
+            "15:00",
+            "15:30",
+            "16:00",
+            "16:30",
+            "18:00",
+            "18:30",
+            "19:00",
+            "19:30",
+            "20:00",
+            "20:30",
         ]
         assert times == expected
 
 
-
 class TestNextBusEdgeCases:
-
     @patch("bus_bot.get_singapore_now")
     def test_during_lunch_break_finds_next_trip(self, mock_now):
         """At 12:30 (weekday lunch break 12:00-13:00), next ASR bus is 13:00."""

--- a/uv.lock
+++ b/uv.lock
@@ -30,8 +30,10 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -43,8 +45,10 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pre-commit", specifier = ">=4.6.0" },
     { name = "pytest", specifier = ">=8" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "ruff", specifier = ">=0.15.12" },
 ]
 
 [[package]]
@@ -57,12 +61,39 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
@@ -115,6 +146,15 @@ wheels = [
 ]
 
 [[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.13"
 source = { registry = "https://pypi.org/simple" }
@@ -133,6 +173,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.1"
 source = { registry = "https://pypi.org/simple" }
@@ -142,12 +191,37 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -200,6 +274,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-discovery"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -222,10 +309,86 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
 ]


### PR DESCRIPTION
## Summary
- Add **ruff** as the project linter and formatter (line-length 99, rules: E, F, I, UP)
- Add **pre-commit** hooks that auto-fix lint and formatting issues on commit
- Add **CI steps** (`ruff check` + `ruff format --check`) before pytest
- Format existing code to comply with ruff

## Test plan
- [x] `ruff check .` and `ruff format --check .` pass
- [x] All 73 tests pass
- [x] Pre-commit hook runs and passes on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)